### PR TITLE
Fixed login redirect to follow the next= query parameter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.19.1 2025-10-09 EBB
+  - Fixed login redirect to correctly follow next= query parameter
 v0.19.0 2025-10-09 JP
   - Introduce dashapp alias field
   - Implement AppCode alias substitution and pass both appcode + alias to the template renderer

--- a/Operations_Dashboard_Django/Operations_Dashboard_Django/urls.py
+++ b/Operations_Dashboard_Django/Operations_Dashboard_Django/urls.py
@@ -36,5 +36,5 @@ urlpatterns = [
     path('', RedirectView.as_view(url='/dashboard') ),
 #    path('', RedirectView.as_view(url=django_settings.LOGIN_URL) )
 #    path('', RedirectView.as_view(url='IntegrationBadgesUI') ),
-    path('login/', RedirectView.as_view(url='/accounts/cilogon/login') )
+    path('login/', RedirectView.as_view(url='/accounts/cilogon/login', query_string=True) )
 ]


### PR DESCRIPTION
Fixed the issue where 
https://betaboard.operations.access-ci.org/login?next=/dashapp/integration_badges_prod/organizations/561
 to https://betaboard.operations.access-ci.org/accounts/cilogon/login/, but 
after login, you go https://betaboard.operations.access-ci.org/dashboard/  instead of to the value in the next= param.

